### PR TITLE
fix: make checksum validation mode configurable, default when_required

### DIFF
--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/ChecksumValidationMode.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/ChecksumValidationMode.java
@@ -1,0 +1,47 @@
+/**
+ * A simple storage implementation for bluemap to save data into s3 storage solution.
+ * Copyright (C) 2025 TheMeinerLP and contributors
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package dev.themeinerlp.bluemap.s3.storage;
+
+/**
+ * The two values the AWS SDK accepts for {@code aws.requestChecksumCalculation} /
+ * {@code aws.responseChecksumValidation}. Kept as our own enum (rather than referencing the SDK's
+ * equivalent) since we only ever need the exact property string, and {@code nio-spi-s3} is our
+ * only declared S3 dependency - its own SDK version is an implementation detail we don't want to
+ * couple to directly.
+ */
+enum ChecksumValidationMode {
+    WHEN_REQUIRED("when_required"),
+    WHEN_SUPPORTED("when_supported");
+
+    private final String propertyValue;
+
+    ChecksumValidationMode(String propertyValue) {
+        this.propertyValue = propertyValue;
+    }
+
+    String propertyValue() {
+        return propertyValue;
+    }
+
+    static ChecksumValidationMode parse(String value) {
+        for (ChecksumValidationMode mode : values()) {
+            if (mode.propertyValue.equalsIgnoreCase(value)) return mode;
+        }
+        return WHEN_REQUIRED;
+    }
+}

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Configuration.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Configuration.java
@@ -33,4 +33,6 @@ public sealed interface S3Configuration permits S3StorageConfiguration {
 
     boolean forcePathStyle();
 
+    String getChecksumValidation();
+
 }

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
@@ -45,6 +45,14 @@ final class S3FileSystemFactory {
             System.setProperty(AWS_REGION_KEY, cfg.getRegion() != null ? cfg.getRegion() : DEFAULT_AWS_REGION);
             System.setProperty("aws.accessKeyId", cfg.getAccessKeyId());
             System.setProperty("aws.secretAccessKey", cfg.getSecretAccessKey());
+            // AWS SDK for Java 2.30.0+ defaults to attaching a flexible checksum (e.g. a CRC32
+            // trailer) to every PutObject and validating one on every GetObject. Many
+            // third-party S3-compatible stores (Ceph RGW included) don't handle that request
+            // shape and reject it with a bare "400 Bad Request", silently failing tile saves.
+            // Configurable per-target since real AWS S3 (and some other providers) are fine
+            // with the new default.
+            System.setProperty("aws.requestChecksumCalculation", cfg.getChecksumValidation());
+            System.setProperty("aws.responseChecksumValidation", cfg.getChecksumValidation());
             if (thirdParty) {
                 var url = URI.create(cfg.getEndpointUrl());
                 if (!url.toString().startsWith("https")) {

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3StorageConfiguration.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3StorageConfiguration.java
@@ -55,7 +55,17 @@ public final class S3StorageConfiguration extends StorageConfig implements S3Con
 
     @Comment("Force path style access for S3 (default: false, use virtual-hosted style)")
     private boolean forcePathStyle = false;
-    
+
+    @Comment("""
+            Controls when the AWS SDK attaches/validates request and response checksums
+            (aws.requestChecksumCalculation / aws.responseChecksumValidation). Since SDK 2.30
+            the default is "when_supported", which adds a checksum to every request - many
+            S3-compatible stores (Ceph RGW included) reject that with a bare 400 Bad Request
+            and silently fail tile saves. Use "when_required" (default here) for those; set it
+            back to "when_supported" if you're on real AWS S3 or a provider that handles it fine.
+            """)
+    private String checksumValidation = "when_required";
+
     @Override
     public Storage createStorage() throws ConfigurationException {
         // Validate required configuration
@@ -119,5 +129,10 @@ public final class S3StorageConfiguration extends StorageConfig implements S3Con
     @Override
     public boolean forcePathStyle() {
         return forcePathStyle;
+    }
+
+    @Override
+    public String getChecksumValidation() {
+        return ChecksumValidationMode.parse(checksumValidation).propertyValue();
     }
 }


### PR DESCRIPTION
## Summary
- AWS SDK for Java 2.30.0+ defaults to attaching a flexible checksum (e.g. CRC32 trailer) to every `PutObject` and validating one on every `GetObject`. This version is pulled in transitively since the `aws-java-nio-spi-for-s3` 2.5.0 bump (#66) — confirmed the `v1.4.7` tag points at exactly that commit.
- Ceph RGW (and most third-party S3-compatible stores) doesn't handle that request shape and rejects it with a bare `400 Bad Request` — silently failing tile saves.
- Confirmed live on production (`Survival-1`): `[BlueMap] Failed to save hires model: (9, 83)` / `S3TransferException: PutObject => 400`, first appearing right after this exact commit was deployed. 5 failed tile saves observed in about 45 minutes of live play.
- Adds a `checksum-validation` config option (`when_required` / `when_supported`, backed by a small `ChecksumValidationMode` enum) controlling `aws.requestChecksumCalculation` / `aws.responseChecksumValidation`, defaulting to `when_required` since this addon's primary audience is third-party S3-compatible stores. Real AWS S3 users can switch it back.

## Context
Background: [aws/aws-sdk-java-v2#5802](https://github.com/aws/aws-sdk-java-v2/discussions/5802) — "S3 default integrity protection change - version 2.30.0". Known, broadly-hit compatibility class of issue between recent AWS SDK v2 and S3-compatible backends (Ceph RGW, MinIO, LocalStack).

## Test plan
- [x] `./gradlew compileJava` passes
- [x] `./gradlew spotlessApply` — no formatting changes beyond this fix
- [ ] Deploy to a Minecraft server pointed at Ceph RGW and confirm no more `PutObject => 400` / `Failed to save hires model` errors after a render/update cycle