### PR TITLE
fix: use inline x-release-please-version annotation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,12 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
+// gradle.properties carries the version as `1.4.7 # x-release-please-version` - the trailing
+// comment is release-please's generic-updater annotation, needed inline on the value line for
+// it to bump this file. `#` mid-line isn't a real Properties comment, so it's part of the raw
+// value; strip it back off here before Gradle uses it anywhere.
+version = (version as String).substringBefore('#').trim()
+
 dependencies {
     implementation(libs.nio.spi.s3)
     compileOnly(libs.bluemap.core)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-# x-release-please-version
-version = 1.4.7
+version = 1.4.7 # x-release-please-version
 group = dev.themeinerlp


### PR DESCRIPTION
## Summary
- The generic extra-files updater needs the `x-release-please-version` annotation as a trailing inline comment on the version line itself, not a leading comment above it — confirmed against `OneLiteFeatherNET/PlayerKits`' actually-working config.
- The leading-comment form (introduced in #74) silently didn't bump `gradle.properties` in the currently open release PR (#75), which is stuck at `1.4.7` while the manifest/tag moved to `1.4.8`.
- Java `.properties` syntax only treats `#` as a comment marker at the start of a line, so once moved inline the annotation becomes part of the raw `version` string (`"1.4.7 # x-release-please-version"`). Strips it back off in `build.gradle.kts` before Gradle uses the version anywhere — same `substringBefore('#')` pattern PlayerKits uses.

## Test plan
- [x] `./gradlew compileJava` passes
- [x] `./gradlew clean shadowJar` produces `BlueMapS3Storage-1.4.7.jar` (clean version string, no trailing comment leaking into the filename)
- [ ] After merge, confirm the open release PR (#75) picks up the fix and correctly shows `gradle.properties` bumped to `1.4.8`