### PR TITLE
feat: add Cloudflare R2 support via account-id and optional list caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A storage addon for [BlueMap](https://github.com/BlueMap-Minecraft/BlueMap) that
 BlueMapS3Storage is an addon for BlueMap that provides the ability to store map data in S3-compatible storage services, such as:
 
 - Amazon S3
+- Cloudflare R2 (see [docs/cloudflare-r2.md](docs/cloudflare-r2.md) for R2-specific setup)
 - MinIO
 - DigitalOcean Spaces
 - Backblaze B2
@@ -107,6 +108,9 @@ force-path-style: true
 | `endpoint-url` | Optional: The endpoint URL for S3-compatible services (leave empty for AWS S3) | `http://localhost:9000` |
 | `root-path` | Optional: The root path in the S3 bucket where BlueMap data will be stored | `.` |
 | `force-path-style` | Optional: Force path style access for S3 (needed for MinIO) | `false` |
+| `checksum-validation` | Controls when the AWS SDK attaches/validates request and response checksums (`when_required` or `when_supported`). Since SDK 2.30 the default is `when_supported`, which many S3-compatible stores (Ceph RGW included) reject with a bare 400 Bad Request. Set to `when_supported` only if you're on real AWS S3 or a provider you've confirmed handles it. | `when_required` |
+| `account-id` | Optional: Cloudflare account ID. If set and `endpoint-url` is left empty, the endpoint is derived automatically as `https://<account-id>.r2.cloudflarestorage.com` with path-style access enabled. See [docs/cloudflare-r2.md](docs/cloudflare-r2.md). | (empty) |
+| `list-cache-ttl-seconds` | Optional: How long to cache the list of available maps (`mapIds()`). Directory listings are a billed operation on some providers (e.g. R2); this list rarely changes at runtime. `0` disables caching. | `0` |
 
 ## Usage Examples
 
@@ -147,6 +151,24 @@ endpoint-url: "http://minio-server:9000"
 root-path: "."
 force-path-style: true
 ```
+
+### Cloudflare R2
+
+```hocon
+##                          ##
+##         BlueMap          ##
+##      Storage-Config      ##
+##                          ##
+
+storage-type: "themeinerlp:s3"
+compression: gzip
+bucket-name: "bluemap-storage"
+account-id: "your-cloudflare-account-id"
+access-key-id: "your-r2-access-key"
+secret-access-key: "your-r2-secret-key"
+```
+
+See [docs/cloudflare-r2.md](docs/cloudflare-r2.md) for full setup steps, the listing-cache option, and troubleshooting.
 
 ### DigitalOcean Spaces
 

--- a/docs/cloudflare-r2.md
+++ b/docs/cloudflare-r2.md
@@ -1,0 +1,84 @@
+# Cloudflare R2
+
+R2 is S3-compatible, so it works through the same `themeinerlp:s3` storage type as any other
+S3-compatible provider. There's no separate `themeinerlp:r2` storage type; two small
+R2-specific conveniences are built into the regular S3 config instead.
+
+## Setup
+
+1. Create a bucket in the Cloudflare dashboard under **R2**.
+2. Under **Manage R2 API Tokens**, create a token with **Object Read & Write** permissions and
+   copy the Access Key ID / Secret Access Key immediately, you won't see them again.
+3. Copy your **Account ID** from the R2 overview page.
+4. Create a storage config file:
+
+   | Platform | Path |
+   |---|---|
+   | Spigot/Paper | `./plugins/BlueMap/storages/r2.conf` |
+   | Sponge/Forge/Fabric | `./config/bluemap/storages/r2.conf` |
+   | CLI | `./config/storages/r2.conf` |
+
+   ```hocon
+   storage-type: "themeinerlp:s3"
+   compression: gzip
+   bucket-name: "your-bucket-name"
+   account-id: "your-account-id"
+   access-key-id: "your-r2-access-key"
+   secret-access-key: "your-r2-secret-key"
+   ```
+
+   Setting `account-id` derives the endpoint (`https://<account-id>.r2.cloudflarestorage.com`)
+   and enables path-style access automatically, since R2 only supports path-style. Leave
+   `endpoint-url` and `force-path-style` unset when using `account-id` this way.
+
+   If you'd rather set the endpoint yourself (e.g. for a jurisdictional/EU-restricted bucket),
+   skip `account-id` and use `endpoint-url`/`force-path-style` directly instead, same as any
+   other S3-compatible provider:
+
+   ```hocon
+   storage-type: "themeinerlp:s3"
+   compression: gzip
+   bucket-name: "your-bucket-name"
+   access-key-id: "your-r2-access-key"
+   secret-access-key: "your-r2-secret-key"
+   region: "auto"
+   endpoint-url: "https://your-account-id.eu.r2.cloudflarestorage.com"
+   force-path-style: true
+   ```
+
+5. Reference the storage in your main BlueMap config:
+
+   ```hocon
+   storages: {
+     r2: "storages/r2.conf"
+   }
+
+   maps: [
+     { id: "world", storage: "r2" }
+   ]
+   ```
+
+6. Restart or reload BlueMap and confirm objects show up in the bucket.
+
+## Cost note: directory listing cache
+
+Directory listings (used for `mapIds()`, i.e. once per storage init/reload to enumerate
+configured maps, not per-tile) are a billed "Class A" operation on R2. Since that list rarely
+changes at runtime, you can cache it for a while:
+
+```hocon
+list-cache-ttl-seconds: 300
+```
+
+`0` (default) disables caching. This only affects map enumeration, not tile reads/writes.
+
+## Troubleshooting
+
+**`SignatureDoesNotMatch` / 403.** Almost always a copy-paste issue: regenerate the R2 API
+token, make sure the secret key isn't wrapped in extra quotes or has trailing whitespace, and
+double check the account ID is the exact 32-character hex string from the R2 overview page
+(not the bucket name or a zone ID).
+
+**`PutObject => 400` / tile saves failing silently.** Not R2-specific, see the
+[`checksum-validation`](../README.md#configuration-options) option. R2 (like most non-AWS
+S3-compatible stores) needs `checksum-validation: when_required` (the default).

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Configuration.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Configuration.java
@@ -35,4 +35,8 @@ public sealed interface S3Configuration permits S3StorageConfiguration {
 
     String getChecksumValidation();
 
+    String getAccountId();
+
+    int getListCacheTtlSeconds();
+
 }

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
@@ -39,7 +39,11 @@ final class S3FileSystemFactory {
             throw new IllegalArgumentException("bucketName is required");
         }
 
-        final boolean thirdParty = cfg.getEndpointUrl() != null && !cfg.getEndpointUrl().isBlank();
+        final boolean noExplicitEndpoint = cfg.getEndpointUrl() == null || cfg.getEndpointUrl().isBlank();
+        final boolean usingAccountId = noExplicitEndpoint && cfg.getAccountId() != null && !cfg.getAccountId().isBlank();
+        final String effectiveEndpoint =
+                usingAccountId ? "https://" + cfg.getAccountId() + ".r2.cloudflarestorage.com" : cfg.getEndpointUrl();
+        final boolean thirdParty = effectiveEndpoint != null && !effectiveEndpoint.isBlank();
         try {
             final URI uri;
             System.setProperty(AWS_REGION_KEY, cfg.getRegion() != null ? cfg.getRegion() : DEFAULT_AWS_REGION);
@@ -54,11 +58,13 @@ final class S3FileSystemFactory {
             System.setProperty("aws.requestChecksumCalculation", cfg.getChecksumValidation());
             System.setProperty("aws.responseChecksumValidation", cfg.getChecksumValidation());
             if (thirdParty) {
-                var url = URI.create(cfg.getEndpointUrl());
+                var url = URI.create(effectiveEndpoint);
                 if (!url.toString().startsWith("https")) {
                     System.setProperty("s3.spi.endpoint-protocol", "http");
                 }
-                if (cfg.forcePathStyle()) {
+                // R2 only supports path-style access, so force it when we derived the endpoint
+                // from account-id, regardless of what force-path-style is set to.
+                if (cfg.forcePathStyle() || usingAccountId) {
                     System.setProperty("s3.spi.force-path-style", "true");
                 }
                 PROVIDER = new S3XFileSystemProvider();

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Storage.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3Storage.java
@@ -17,6 +17,7 @@
  */
 package dev.themeinerlp.bluemap.s3.storage;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import de.bluecolored.bluemap.core.storage.MapStorage;
@@ -24,23 +25,37 @@ import de.bluecolored.bluemap.core.storage.Storage;
 import de.bluecolored.bluemap.core.storage.compression.Compression;
 import de.bluecolored.bluemap.core.storage.file.FileMapStorage;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 
 public final class S3Storage implements Storage {
+
+    private static final String MAP_IDS_CACHE_KEY = "mapIds";
 
     private final S3Configuration configuration;
     private final Compression compression;
     private FileSystem s3FileSystem;
     private boolean closed = false;
     private final LoadingCache<String, FileMapStorage> mapStorages;
+    // Directory listings are a billed "Class A" operation on R2 and similar providers, so
+    // mapIds() (which rarely changes at runtime) can optionally be cached for a while. Null
+    // when list-cache-ttl-seconds is 0, meaning caching stays off unless explicitly configured.
+    private final Cache<String, List<String>> mapIdsCache;
 
     public S3Storage(S3Configuration configuration, Compression compression) {
         this.configuration = configuration;
         this.compression = compression;
         mapStorages = Caffeine.newBuilder().build(this::create);
+        int listCacheTtlSeconds = configuration.getListCacheTtlSeconds();
+        mapIdsCache =
+                listCacheTtlSeconds > 0
+                        ? Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(listCacheTtlSeconds)).build()
+                        : null;
     }
 
     @Override
@@ -83,12 +98,24 @@ public final class S3Storage implements Storage {
         if (isClosed()) {
             throw new IOException("Storage is closed");
         }
-        
-        // List all directories in the root path
-        return Files.list(getRooPath())
-                .filter(Files::isDirectory)
-                .map(Path::getFileName)
-                .map(Path::toString);
+
+        try {
+            List<String> ids =
+                    mapIdsCache != null
+                            ? mapIdsCache.get(MAP_IDS_CACHE_KEY, key -> listMapIdsUncached())
+                            : listMapIdsUncached();
+            return ids.stream();
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private List<String> listMapIdsUncached() {
+        try (Stream<Path> entries = Files.list(getRooPath())) {
+            return entries.filter(Files::isDirectory).map(Path::getFileName).map(Path::toString).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3StorageConfiguration.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3StorageConfiguration.java
@@ -66,6 +66,24 @@ public final class S3StorageConfiguration extends StorageConfig implements S3Con
             """)
     private String checksumValidation = "when_required";
 
+    @Comment("""
+            Optional: Cloudflare account ID. If set and endpoint-url is left empty, the
+            endpoint is derived automatically as https://<account-id>.r2.cloudflarestorage.com
+            and path-style access is enabled (required by R2). Leave empty for AWS S3 or any
+            other S3-compatible provider - use endpoint-url directly for those instead.
+            """)
+    @DebugDump(exclude = true)
+    private String accountId = "";
+
+    @Comment("""
+            How long (in seconds) to cache the result of listing available maps (mapIds()).
+            0 disables caching (default). Directory listings are a billed "Class A" operation
+            on R2 and similar providers, so a short cache here cuts down on repeated listing
+            calls; this list rarely changes at runtime (only when a map is added/removed), so
+            a stale cache for a few minutes is normally harmless.
+            """)
+    private int listCacheTtlSeconds = 0;
+
     @Override
     public Storage createStorage() throws ConfigurationException {
         // Validate required configuration
@@ -134,5 +152,15 @@ public final class S3StorageConfiguration extends StorageConfig implements S3Con
     @Override
     public String getChecksumValidation() {
         return ChecksumValidationMode.parse(checksumValidation).propertyValue();
+    }
+
+    @Override
+    public String getAccountId() {
+        return accountId;
+    }
+
+    @Override
+    public int getListCacheTtlSeconds() {
+        return Math.max(0, listCacheTtlSeconds);
     }
 }


### PR DESCRIPTION
## Summary

Ports the useful parts of Tresillo2017's R2 fork (`compare/main...Tresillo2017:BlueMapS3Storage:main`) cleanly. That fork's diff turned out to contain **no actual Java changes** despite its `CHANGELOG_R2.md` describing new `R2Storage`/`R2Configuration`/`R2FileSystemFactory` classes: just three overlapping markdown files and an accidentally-committed `node_modules/` (295 files).

R2 is S3-compatible, so it already works through the existing `themeinerlp:s3` storage type (their own docs even note this as a "workaround"). Rather than duplicating that as a parallel R2-specific implementation, this adds two small, real conveniences to the existing config instead:

- **`account-id`**: optional Cloudflare account ID. When set (and `endpoint-url` is left empty), the endpoint is derived automatically as `https://<account-id>.r2.cloudflarestorage.com` and path-style access is forced on, since R2 only supports path-style.
- **`list-cache-ttl-seconds`**: optional TTL cache for `mapIds()` (map enumeration), since directory listings are a billed "Class A" operation on R2. Off by default (`0`); only affects map enumeration at init/reload, not tile reads/writes. Fixed a pre-existing resource leak in `mapIds()` along the way, the underlying `DirectoryStream` was never closed.

Consolidates the fork's `R2_GUIDE.md`/`R2_QUICK_START.md`/`CHANGELOG_R2.md` into a single `docs/cloudflare-r2.md`, and documents both new options plus the existing `checksum-validation` option (added in #73 but never added to the README) in the main config table.

## Test plan
- [x] `./gradlew compileJava` passes
- [x] `./gradlew spotlessApply` — no formatting changes beyond this feature
- [ ] Configure `account-id` against a real R2 bucket and confirm the endpoint/path-style derivation works end to end