### PR TITLE
fix: don't set global credential system properties for third-party S3 targets

### DIFF
--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
@@ -45,8 +45,6 @@ final class S3FileSystemFactory {
             final URI uri;
             String region = resolved.region() != null && !resolved.region().isBlank() ? resolved.region() : DEFAULT_AWS_REGION;
             System.setProperty(AWS_REGION_KEY, region);
-            System.setProperty("aws.accessKeyId", cfg.getAccessKeyId());
-            System.setProperty("aws.secretAccessKey", cfg.getSecretAccessKey());
             // AWS SDK for Java 2.30.0+ defaults to attaching a flexible checksum (e.g. a CRC32
             // trailer) to every PutObject and validating one on every GetObject. Many
             // third-party S3-compatible stores (Ceph RGW included) don't handle that request
@@ -64,10 +62,27 @@ final class S3FileSystemFactory {
                     System.setProperty("s3.spi.force-path-style", "true");
                 }
                 PROVIDER = new S3XFileSystemProvider();
+                // Credentials travel in the URI's userInfo below, scoped to this one
+                // filesystem - deliberately NOT also written to the aws.accessKeyId/
+                // aws.secretAccessKey system properties here. Those are process-wide mutable
+                // state; any other credential resolution in this JVM that reads the default
+                // AWS credentials chain (e.g. an async/background client the nio-spi-s3
+                // library spins up internally, distinct from the client that honors the URI)
+                // would see whatever this storage's config last wrote there, independent of
+                // which storage's requests are actually in flight at that moment. Observed in
+                // production as intermittent, unpredictable 403s specifically on the async
+                // read-ahead path (S3ReadAheadByteChannel) against a third-party store (Ceph
+                // RGW), with the rejected requests showing no identifiable user at all -
+                // consistent with a credential resolution racing against a value this method
+                // (or another instance of it) had already overwritten.
                 String userInfo = buildUserInfo(cfg);
                 uri = new URI("s3x", userInfo, url.getHost(), url.getPort(), "/" + cfg.getBucketName(), null, null);
             } else {
-                // AWS S3 – the provider uses the default region/credentials chain
+                // AWS S3 – the provider uses the default region/credentials chain, which has
+                // no URI-embedded alternative for this code path, so these two properties are
+                // the only way to hand it credentials.
+                System.setProperty("aws.accessKeyId", cfg.getAccessKeyId());
+                System.setProperty("aws.secretAccessKey", cfg.getSecretAccessKey());
                 PROVIDER = new S3FileSystemProvider();
 
                 uri = new URI("s3","/" + cfg.getBucketName(), null, null);

--- a/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
+++ b/src/main/java/dev/themeinerlp/bluemap/s3/storage/S3FileSystemFactory.java
@@ -62,25 +62,12 @@ final class S3FileSystemFactory {
                     System.setProperty("s3.spi.force-path-style", "true");
                 }
                 PROVIDER = new S3XFileSystemProvider();
-                // Credentials travel in the URI's userInfo below, scoped to this one
-                // filesystem - deliberately NOT also written to the aws.accessKeyId/
-                // aws.secretAccessKey system properties here. Those are process-wide mutable
-                // state; any other credential resolution in this JVM that reads the default
-                // AWS credentials chain (e.g. an async/background client the nio-spi-s3
-                // library spins up internally, distinct from the client that honors the URI)
-                // would see whatever this storage's config last wrote there, independent of
-                // which storage's requests are actually in flight at that moment. Observed in
-                // production as intermittent, unpredictable 403s specifically on the async
-                // read-ahead path (S3ReadAheadByteChannel) against a third-party store (Ceph
-                // RGW), with the rejected requests showing no identifiable user at all -
-                // consistent with a credential resolution racing against a value this method
-                // (or another instance of it) had already overwritten.
+                // Credentials go through the URI userInfo instead of the global
+                // aws.accessKeyId/aws.secretAccessKey properties - see PR #83.
                 String userInfo = buildUserInfo(cfg);
                 uri = new URI("s3x", userInfo, url.getHost(), url.getPort(), "/" + cfg.getBucketName(), null, null);
             } else {
-                // AWS S3 – the provider uses the default region/credentials chain, which has
-                // no URI-embedded alternative for this code path, so these two properties are
-                // the only way to hand it credentials.
+                // AWS S3: no URI-embedded credentials, so these are the only way to set them.
                 System.setProperty("aws.accessKeyId", cfg.getAccessKeyId());
                 System.setProperty("aws.secretAccessKey", cfg.getSecretAccessKey());
                 PROVIDER = new S3FileSystemProvider();


### PR DESCRIPTION
## Summary

For third-party/S3-compatible endpoints (Ceph RGW, R2, MinIO, ...), credentials already travel scoped to the filesystem instance via the `s3x://` URI's `userInfo` (`accessKeyId:secretAccessKey`). `S3FileSystemFactory.build()` additionally wrote the same credentials to the **process-wide** `aws.accessKeyId`/`aws.secretAccessKey` system properties unconditionally, before branching on `thirdParty`.

That's redundant for the third-party path, and unsafe: system properties are global mutable JVM state. Any credential resolution elsewhere in the same JVM that falls back to the default AWS credentials chain — rather than using the URI-scoped credentials this method sets up — reads whatever value was written there most recently, independent of which storage's request is actually in flight.

## What prompted this

Running BlueMapS3Storage against Ceph RGW in production, I started seeing an elevated Ceph RGW failed-request-rate alert. Investigation (RGW access logs, `radosgw-admin bucket stats`/`user info`, Kubernetes secret contents) ruled out:
- Stale/rotated credentials — the access key in the mounted config matches the active RGW key exactly.
- Bucket ownership — `bucket stats` confirms `bluemap` owns the bucket.
- A recent config/deploy change — nothing changed in the days around when the failures started.

What stood out: 99.8% of the failing requests were `GET .../tiles/<...>` reads, rejected with **no identifiable authenticated user at all** (blank, not "wrong user") — and the original crash that kicked off the investigation was a `409` thrown from `S3ReadAheadByteChannel` (the async read-ahead path in `aws-java-nio-spi-for-s3`), not from the synchronous request path.

That pointed at the async path resolving credentials differently than the synchronous one — and `S3FileSystemFactory` writing credentials to global system properties, unconditionally, is the one place in this codebase where that kind of cross-path interference could happen.

## Fix

Only set `aws.accessKeyId`/`aws.secretAccessKey` on the real-AWS-S3 branch, which has no URI-based credential mechanism and genuinely needs them. The third-party/S3X branch now relies solely on the URI-embedded credentials it already had.

## Confidence level

Honest caveat: this is a **hypothesis-driven fix**, not a confirmed-and-reproduced one — the failure is intermittent (roughly 2-17 failed req/s in bursts, not constant), and I don't have a minimal repro isolating the exact internal code path in `aws-java-nio-spi-for-s3` that falls back to the system-property-based default credentials chain. The change itself is low-risk (it only *removes* a redundant write on the third-party path; the real-AWS-S3 path is untouched), so I think it's worth merging and monitoring rather than blocking on a full repro.

## Test plan

- [x] `./gradlew compileJava` — builds clean
- [x] `./gradlew spotlessCheck` — formatting passes
- [ ] Monitor Ceph RGW failed-request-rate after deploying this to the production server that surfaced the issue — should drop back to baseline (<1 req/s) if this was the cause